### PR TITLE
fix issue with ptb builds getting copied to an inconsistent place

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -404,8 +404,10 @@ jobs:
     - name: (macOS) Prep binary for running tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       run: |
-        if [ -d "${{runner.workspace}}/b/ninja/upload/${{env.UPLOAD_FILENAME}}.app" ]; then
-          cp -r ${{runner.workspace}}/b/ninja/upload/${{env.UPLOAD_FILENAME}}.app ~/Desktop/Mudlet.app
+        if [ -d "${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app" ]; then
+          cp -r ${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app ~/Desktop/Mudlet.app
+        elif [ -d "${{runner.workspace}}/b/ninja/Mudlet PTB.app" ]; then
+          cp -r "${{runner.workspace}}/b/ninja/Mudlet PTB.app" ~/Desktop/Mudlet.app
         else
           cp -r ${{runner.workspace}}/b/ninja/src/mudlet.app ~/Desktop/Mudlet.app
         fi

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -404,13 +404,13 @@ jobs:
     - name: (macOS) Prep binary for running tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       run: |
-        if [ -d "${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app" ]; then
-          cp -r ${{runner.workspace}}/b/ninja/${{env.UPLOAD_FILENAME}}.app ~/Desktop/Mudlet.app
+        if [ -d "${{runner.workspace}}/b/ninja/upload/${{env.UPLOAD_FILENAME}}.app" ]; then
+          cp -r ${{runner.workspace}}/b/ninja/upload/${{env.UPLOAD_FILENAME}}.app ~/Desktop/Mudlet.app
         else
           cp -r ${{runner.workspace}}/b/ninja/src/mudlet.app ~/Desktop/Mudlet.app
         fi
         cd ~/Desktop
-        sudo codesign --remove-signature Mudlet.app
+        sudo codesign --remove-signature ~/Desktop/Mudlet.app
       shell: bash
 
     - name: (Linux) Run Lua tests

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -76,10 +76,10 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
     echo "=== ... later, via Github ==="
     # Move the finished file into a folder of its own, because we ask Github to upload contents of a folder
-    mkdir "upload/"
-    mv "${HOME}/Desktop/${appBaseName}.dmg" "upload/"
+    mkdir -p "${BUILD_DIR}/upload/"
+    mv "${HOME}/Desktop/${appBaseName}.dmg" "${BUILD_DIR}/upload/"
     {
-      echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
+      echo "FOLDER_TO_UPLOAD=${BUILD_DIR}/upload"
       echo "UPLOAD_FILENAME=${appBaseName}"
     } >> "$GITHUB_ENV"
     DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
@@ -126,10 +126,10 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Setting up for Github upload ==="
-      mkdir "upload/"
-      mv "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}.dmg" "upload/"
+      mkdir -p "${BUILLD_DIR}/upload/"
+      mv "${HOME}/Desktop/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}.dmg" "${BUILD_DIR}/upload/"
       {
-        echo "FOLDER_TO_UPLOAD=$(pwd)/upload"
+        echo "FOLDER_TO_UPLOAD=${BUILD_DIR}/upload"
         echo "UPLOAD_FILENAME=Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-${BUILD_COMMIT}-${ARCH}"
       } >> "$GITHUB_ENV"
       DEPLOY_URL="Github artifact, see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix issue identified during PTB test builds for macOS: https://github.com/Mudlet/Mudlet/actions/runs/11452314380/job/31862980322#step:31:2

#### Motivation for adding to Mudlet
Make builds work again.

#### Other info (issues closed, discussion etc)

The issue was that the "upload" directory was being created based on the cwd, which can vary in some cases. Standardize to use ${BUILD_DIR}/upload across the board.
